### PR TITLE
feat: 审核列表显示岗位对应的公司名称，显示岗位对应薪资，新增外包公司过滤、HR活跃度筛选、称呼个性化

### DIFF
--- a/JobCopilot · AI/manifest.json
+++ b/JobCopilot · AI/manifest.json
@@ -12,6 +12,12 @@
   "content_scripts": [
     {
       "matches": ["*://*.zhipin.com/web/geek/job*"],
+      "js": ["src/hook-api.js"],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
+    {
+      "matches": ["*://*.zhipin.com/web/geek/job*"],
       "js": ["src/selectors.js", "src/content-search.js"],
       "run_at": "document_idle"
     },

--- a/JobCopilot · AI/src/background.js
+++ b/JobCopilot · AI/src/background.js
@@ -22,10 +22,49 @@ function log(text, level) { chrome.runtime.sendMessage({ type: 'LOG', text: text
 function pushPhase() { chrome.runtime.sendMessage({ type: 'PHASE', phase: state.phase }).catch(() => {}); }
 function progress(cur, total, label) { chrome.runtime.sendMessage({ type: 'PROGRESS', cur: cur, total: total, label: label || '' }).catch(() => {}); }
 async function waitIfPaused() { while (state.paused && !state.aborted) await sleep(400); }
-function getCfg() { return chrome.storage.local.get(['dsKey', 'resumeText', 'resumeImage', 'city', 'keyword', 'count']); }
+function getCfg() { return chrome.storage.local.get(['dsKey', 'resumeText', 'resumeImage', 'city', 'keyword', 'count', 'outKeywords', 'activeFilter']); }
 function resumeFull(cfg) { return (cfg.resumeText || '').trim(); }
 function jobInfo(j) { return '岗位：' + (j.name || '') + '\n技能标签：' + ((j.tags || []).join('、')) + '\n薪资：' + (j.salary || '') + '\n公司：' + (j.company || ''); }
 function findJob(id) { for (var i = 0; i < state.jobs.length; i++) if (state.jobs[i].id === id) return state.jobs[i]; return null; }
+
+// 本地黑名单过滤：公司名/岗位名/标签命中排除词，直接判不匹配，不消耗 AI
+function localOutsourceFilter(cfg, job) {
+  const words = (cfg.outKeywords || '').split(/[,，;；\s]+/).map(s => s.trim().toLowerCase()).filter(Boolean);
+  if (!words.length) return null;
+  const text = [job.company || '', job.name || '', (job.tags || []).join(' ')].join(' ').toLowerCase();
+  for (const w of words) {
+    if (text.indexOf(w) >= 0) return { match: false, reason: '命中排除词「' + w + '」' };
+  }
+  return null;
+}
+
+// 活跃度等级：刚刚活跃=5 > 今日=4 > 3日内=3 > 本周=2 > 本月=1 > 几乎不活跃=0；未知=-1
+function activityLevel(s) {
+  s = s || '';
+  if (s.indexOf('刚刚活跃') >= 0) return 5;
+  if (s.indexOf('在线') >= 0) return 5;
+  if (s.indexOf('今日活跃') >= 0) return 4;
+  const m = s.match(/(\d+)日内活跃/);
+  if (m) return 3;
+  if (s.indexOf('本周活跃') >= 0) return 2;
+  if (s.indexOf('本月活跃') >= 0) return 1;
+  if (s.indexOf('几乎不活跃') >= 0) return 0;
+  return -1;
+}
+
+// 活跃度筛选：要求等级以上的保留；未知不拦截（避免误杀）
+function localActivityFilter(cfg, job) {
+  const req = parseInt(cfg.activeFilter, 10);
+  if (!req) return null;
+  let lv = activityLevel(job.activity);
+  if (job.bossOnline === true && lv < 5) lv = 5; // 在线视同高活跃
+  if (lv < 0) return null;
+  if (lv < req) return { match: false, reason: 'HR活跃度不足：' + (job.activity || '离线') + '（要求' + reqLabel(req) + '）' };
+  return null;
+}
+function reqLabel(req) {
+  return { 5: '刚刚活跃', 4: '今日活跃', 3: '3日内活跃', 2: '本周活跃', 1: '本月活跃' }[req] || String(req);
+}
 
 // ── DeepSeek ──
 async function callDS(messages, maxTokens) {
@@ -43,7 +82,7 @@ async function callDS(messages, maxTokens) {
 
 // 筛选：只判断是否值得投（用岗位标签快速判断，不生成招呼语）
 async function screenJob(cfg, job) {
-  const sys = '你是资深求职助手。请完全依据下面提供的【求职者简历】，判断某个岗位是否值得该求职者投递。\n【判断标准·适中】保留(match=true)：岗位方向与求职者简历的专业/技能/经历相关，且求职者的经验年限、学历、级别够得着该岗位（不超纲）。剔除(match=false)：方向与简历明显无关；岗位要求的经验/学历/硬技能明显超出简历；岗位级别明显高于求职者当前水平。请依据简历本身判断，不要套用任何固定行业或级别。\n【输出】只输出一个JSON对象，不要markdown：{"match":true或false,"reason":"一句话理由"}';
+  const sys = '你是资深求职助手。请完全依据下面提供的【求职者简历】，判断某个岗位是否值得该求职者投递。\n【判断标准·适中】保留(match=true)：岗位方向与求职者简历的专业/技能/经历相关，且求职者的经验年限、学历、级别够得着该岗位（不超纲）。剔除(match=false)：方向与简历明显无关；岗位要求的经验/学历/硬技能明显超出简历；岗位级别明显高于求职者当前水平；公司为外包/劳务派遣/人力资源外包性质（包括公司名含"外包、人力、派遣、众包"等字样，或岗位明确要求"外派、驻场"，或属于知名外包企业如中软国际、软通动力、博彦科技、京北方等）。请依据简历本身判断，不要套用任何固定行业或级别。\n【输出】只输出一个JSON对象，不要markdown：{"match":true或false,"reason":"一句话理由"}';
   const user = '求职者简历：\n' + resumeFull(cfg) + '\n\n待判断岗位：\n' + jobInfo(job) + '\n\n严格输出JSON。';
   const raw = await callDS([{ role: 'system', content: sys }, { role: 'user', content: user }], 200);
   let p = null;
@@ -52,11 +91,57 @@ async function screenJob(cfg, job) {
   return { match: p.match === true, reason: p.reason || '' };
 }
 
+// 常见复姓（保守起见复姓不自动加称呼，避免"欧姐/欧哥"式尴尬）
+const COMPOUND_SURNAMES = ['欧阳', '司马', '诸葛', '上官', '东方', '慕容', '独孤', '夏侯', '尉迟', '公孙', '皇甫', '南宫', '端木', '轩辕', '令狐', '闻人', '司徒', '司空', '长孙', '申屠', '公冶', '宗政', '濮阳', '淳于', '单于', '太叔'];
+// 强性别倾向用字（名中命中即推断，宁缺毋滥，中性字一律不收）
+const MALE_CHARS = '伟强磊军杰涛斌勇超浩鹏峰飞亮刚建东志波辉凯鑫博俊林海富坤铭勋腾翔健威锋岩松毅晨豪康宏泽轩然昊睿天翼航硕辰启瑞鸿达庆权汉彬彪帅迪帆舟';
+const FEMALE_CHARS = '芳敏静丽娟燕婷雪梅红霞英玉秀兰慧洁怡淑妍丹娜媛萍玲凤美琴云珍蓉虹颖珊琪瑶萌婉蕾莉薇萱诺欣梦佳月秋露晶甜艺蕊芸';
+
+function nameGender(name) {
+  if (!name) return null;
+  let male = 0, female = 0;
+  for (const ch of name) {
+    if (MALE_CHARS.indexOf(ch) >= 0) male++;
+    if (FEMALE_CHARS.indexOf(ch) >= 0) female++;
+  }
+  if (male && !female) return '男';
+  if (female && !male) return '女';
+  return null; // 都命中或都没命中 → 不确定
+}
+
+// 从 HR 名字推导称呼：先生/女士后缀最可靠；没有后缀时按姓名用字性别偏好推断；
+// 仍不确定一律返回 null（不硬叫，避免叫错性别）
+function deriveGreeting(job) {
+  const n = (job.hrName || '').trim();
+  if (!n) return null;
+  // 1) 姓+先生/女士（如 李女士、王先生）
+  const m = n.match(/^([\u4e00-\u9fa5]{1,2})(先生|女士)$/);
+  if (m) {
+    if (COMPOUND_SURNAMES.indexOf(m[1]) >= 0) return null; // 复姓，保守不称呼
+    const surname = m[1].charAt(0);
+    return m[2] === '先生' ? surname + '哥' : surname + '姐';
+  }
+  // 2) 纯中文姓名（如 张伟、李静）按名推断性别
+  const pure = (n.match(/[\u4e00-\u9fa5]{2,4}/) || [''])[0];
+  if (pure.length < 2) return null;
+  let surname = pure.charAt(0);
+  for (const cs of COMPOUND_SURNAMES) {
+    if (pure.indexOf(cs) === 0) { surname = cs; break; }
+  }
+  const given = pure.slice(surname.length);
+  const g = nameGender(given);
+  if (!g) return null;
+  return g === '男' ? surname + '哥' : surname + '姐';
+}
+
 // 投递时：结合该岗位的【完整JD】+ 简历，现场生成专属招呼语
-async function genGreetingFromJD(cfg, job, jd) {
-  const sys = '你是求职者本人，在BOSS直聘给HR发招呼语。回复会原样发给HR，严禁任何注释、说明、括号备注、字数统计或引导语。\n【格式】1.开头前15字必须是"熟悉XXX、XXX"(填该JD要求且你简历具备的核心技能1-2个)。2.紧接"做过XXX"说明简历里与该岗位相关的具体项目/经历。3.全文80-120字，真诚自然。';
+async function genGreetingFromJD(cfg, job, jd, callName) {
+  const callRule = callName
+    ? '开头第一句必须先写称呼「' + callName + '，您好！」，例如：「' + callName + '，您好！我熟悉…」'
+    : '开头第一句必须先写「您好！」问候，例如：「您好！我熟悉…」';
+  const sys = '你是求职者本人，在BOSS直聘给HR发招呼语。回复会原样发给HR，严禁任何注释、说明、括号备注、字数统计或引导语。\n【格式】1.' + callRule + '。2.紧接"做过XXX"说明简历里与该岗位相关的具体项目/经历。3.全文80-120字，真诚自然。';
   const jdText = (jd && jd.trim()) ? jd.trim() : ('技能标签：' + (job.tags || []).join('、'));
-  const user = '我的简历：\n' + resumeFull(cfg) + '\n\n目标岗位：' + (job.name || '') + (job.company ? ('（' + job.company + '）') : '') + '\n该岗位JD：\n' + jdText + '\n\n请按格式生成一段招呼语，开头必须"熟悉…"，直接输出招呼语本身，不要任何多余内容。';
+  const user = '我的简历：\n' + resumeFull(cfg) + '\n\n目标岗位：' + (job.name || '') + (job.company ? ('（' + job.company + '）') : '') + '\n该岗位JD：\n' + jdText + '\n\n请按格式生成一段招呼语' + (callName ? '（HR姓' + callName.charAt(0) + '，开头必须称呼' + callName + '）' : '（开头必须先写"您好！"问候，再接"我熟悉…"）') + '，直接输出招呼语本身，不要任何多余内容。';
   const raw = await callDS([{ role: 'system', content: sys }, { role: 'user', content: user }], 300);
   return (raw || '').trim();
 }
@@ -137,9 +222,14 @@ async function runCollect() {
     if (state.aborted) break; await waitIfPaused();
     const batch = state.jobs.slice(i, i + CONC);
     await Promise.all(batch.map(async (job) => {
-      let res;
-      try { res = await screenJob(cfg, job); }
-      catch (e) { res = { match: false, reason: '筛选异常:' + e.message }; }
+      // 本地规则：黑名单 → 活跃度 → AI
+      const local = localOutsourceFilter(cfg, job);
+      const act = local ? null : localActivityFilter(cfg, job);
+      let res = local || act;
+      if (!res) {
+        try { res = await screenJob(cfg, job); }
+        catch (e) { res = { match: false, reason: '筛选异常:' + e.message }; }
+      }
       state.screened.push(Object.assign({}, job, { match: res.match, reason: res.reason }));
       done++; progress(done, total, '筛选');
     }));
@@ -177,11 +267,17 @@ async function runDeliver(jobIds) {
     log('  读取岗位JD...');
     const jdr = await sendToTab(tab.id, { type: 'OPEN_JD', job: job });
     const jd = (jdr && jdr.jd) || '';
+    // 卡片上没抓到公司名时，用详情面板的兜底
+    if (jdr && jdr.company && !job.company) job.company = jdr.company;
+    if (jdr && jdr.companyLink && !job.companyLink) job.companyLink = jdr.companyLink;
+    if (jdr && jdr.hrName && !job.hrName) job.hrName = jdr.hrName;
 
     // 2. 用【完整JD + 简历】现场生成这个岗位专属的招呼语
     log('  AI生成专属招呼语...');
     let greeting = '';
-    try { greeting = await genGreetingFromJD(cfg, job, jd); } catch (e) { log('  生成失败：' + e.message, 'error'); }
+    const callName = deriveGreeting(job);
+    if (callName) log('  称呼：' + callName);
+    try { greeting = await genGreetingFromJD(cfg, job, jd, callName); } catch (e) { log('  生成失败：' + e.message, 'error'); }
     if (!greeting) { recordFail(job, '招呼语生成失败'); log('  招呼语为空，跳过', 'warn'); progress(k + 1, ids.length, '投递'); continue; }
 
     // 3. 点立即沟通 → 继续沟通（跳聊天页）

--- a/JobCopilot · AI/src/content-search.js
+++ b/JobCopilot · AI/src/content-search.js
@@ -5,7 +5,29 @@
 
   const sleep = (ms) => new Promise(r => setTimeout(r, ms));
 
+  // 接收 MAIN world 钩子脚本（hook-api.js）截获的 BOSS 搜索接口明文数据
+  const apiCache = [];
+  window.addEventListener('message', (ev) => {
+    if (ev.source !== window || !ev.data || ev.data.source !== 'zp-hook' || !ev.data.payload) return;
+    const p = ev.data.payload;
+    if (!p || !Array.isArray(p.list) || !p.list.length) return;
+    if (apiCache.some(x => x.url === p.url && x.list.length === p.list.length)) return;
+    apiCache.push(p);
+  });
+
   function getCards() { return Array.from(document.querySelectorAll(SELECTORS.jobs.jobCard)); }
+
+  // 依次尝试多个选择器，取第一个非空文本（去空白），避免单个选择器失效就抓空
+  function pickText(root, sels) {
+    for (const sel of sels) {
+      const el = root.querySelector(sel);
+      if (el) {
+        const t = (el.textContent || '').replace(/\s+/g, ' ').trim();
+        if (t) return t;
+      }
+    }
+    return '';
+  }
 
   function parseCard(card) {
     const nameEl = card.querySelector(SELECTORS.jobs.jobName);
@@ -15,17 +37,124 @@
     const m = link.match(/job_detail\/([^.?]+)\.html/);
     const id = (m && m[1]) || ((nameEl ? nameEl.textContent.trim() : '') + '|' + (salEl ? salEl.textContent.trim() : ''));
     const tags = Array.from(card.querySelectorAll(SELECTORS.jobs.tagList)).map(t => t.textContent.trim()).filter(Boolean);
-    let company = '';
-    const compEl = card.querySelector('.company-name a, .company-name, [class*="company-name"], .boss-info .company-name, .company-info a, [class*="company"] a');
-    if (compEl) company = compEl.textContent.trim();
+    // 当前版卡片：公司名在 .boss-name（链接 /gongsi/ 公司页）；旧版在 .company-name
+    const company = pickText(card, [
+      '.boss-info .boss-name',
+      '.boss-name',
+      '.company-info .company-name a, .company-info .company-name',
+      '.job-card-footer .company-info .name a, .job-card-footer .company-info .name',
+      '.company-text .name a, .company-text .name',
+      '.company-name',
+      '[class*="company-name"]'
+    ]);
+    const coLinkEl = card.querySelector('a[href*="/gongsi/"]') || card.querySelector('a[href*="/company_detail/"]');
+    const companyLink = coLinkEl ? coLinkEl.href : '';
+    // 当前版卡片不再显示 HR 名字（.boss-name 是公司名），HR 名留到详情面板/聊天页再读
+    const hrName = '';
+    const area = pickText(card, [SELECTORS.jobs.jobArea]);
+    // 卡片文本里抓 HR 活跃度（刚刚活跃/今日活跃/3日内活跃/本周活跃/本月活跃）
+    const actM = (card.textContent || '').match(/(刚刚活跃|今日活跃|\d+日内活跃|本周活跃|本月活跃|几乎不活跃)/);
+    const activity = actM ? actM[1] : '';
     return {
       id: id,
       name: nameEl ? nameEl.textContent.trim() : '未知岗位',
       salary: salEl ? salEl.textContent.trim() : '',
       tags: tags,
       company: company,
+      companyLink: companyLink,
+      hrName: hrName,
+      area: area,
+      activity: activity,
       link: link
     };
+  }
+
+  // BOSS 用动态字体加密薪资数字（DOM 拿到的是乱码），改从页面自己的搜索 API 拿明文
+  // salaryDesc / brandName / bossName，一并回填公司全名和 HR 名
+  async function enrichFromApi(jobs) {
+    let hit = 0;
+    try {
+      // 1) 优先用钩子截获的页面原始接口数据（带全量风控参数，最可靠）
+      document.dispatchEvent(new CustomEvent('zp-hook-request'));
+      await sleep(400);
+      const byId = {};
+      for (const p of apiCache) {
+        for (const it of p.list) {
+          if (it.encryptJobId) byId[it.encryptJobId] = it;
+          if (it.jobId) byId[it.jobId] = it;
+        }
+      }
+      const applyApi = (it, job) => {
+        if (it.salaryDesc) job.salary = it.salaryDesc;
+        if (it.brandName) job.company = it.brandName;
+        if (it.bossName) job.hrName = it.bossName;
+        if (it.bossAvatar) job.bossAvatar = it.bossAvatar;
+        if (typeof it.bossOnline !== 'undefined') job.bossOnline = it.bossOnline;
+        // 不管字段名叫什么，只要值里带活跃度文本就抓下来
+        if (!job.activity) {
+          for (const k in it) {
+            const v = it[k];
+            if (typeof v === 'string' && /(刚刚活跃|今日活跃|\d+日内活跃|本周活跃|本月活跃|几乎不活跃)/.test(v)) {
+              job.activity = v;
+              break;
+            }
+          }
+        }
+      };
+      for (const job of jobs) {
+        const it = byId[job.id];
+        if (!it) continue;
+        hit++;
+        applyApi(it, job);
+      }
+      // 2) 兜底：id 对不上时，按 岗位名 + 公司名 匹配（名称组合足够唯一）
+      if (!hit) {
+        const allItems = [];
+        for (const p of apiCache) allItems.push.apply(allItems, p.list);
+        for (const job of jobs) {
+          const it = allItems.find(x => x.jobName === job.name && x.brandName && job.company
+            && (x.brandName.indexOf(job.company) >= 0 || job.company.indexOf(x.brandName) >= 0));
+          if (!it) continue;
+          hit++;
+          applyApi(it, job);
+        }
+      }
+      if (hit) return hit;
+
+      // 3) 再兜底：按已知路径直接请求（可能因缺风控参数失败）
+      let apiUrl = '';
+      const resources = performance.getEntriesByType('resource').map(e => e.name);
+      apiUrl = resources.find(u => u.indexOf('/wapi/zpgeek/') >= 0 && u.indexOf('joblist') >= 0) || '';
+      if (!apiUrl) {
+        const u = new URL(location.href);
+        const p = new URLSearchParams({ scene: 1, query: u.searchParams.get('query') || '', city: u.searchParams.get('city') || '100010000', page: 1, pageSize: 30 });
+        apiUrl = location.origin + '/wapi/zpgeek/search/joblist.json?' + p.toString();
+      }
+      const pages = Math.min(Math.ceil(jobs.length / 30), 2) || 1;
+      for (let pg = 1; pg <= pages; pg++) {
+        const url = new URL(apiUrl);
+        url.searchParams.set('page', pg);
+        const resp = await fetch(url.href, { credentials: 'include' });
+        if (!resp.ok) continue;
+        const data = await resp.json();
+        const list = (data && data.zpData && Array.isArray(data.zpData.jobList)) ? data.zpData.jobList : [];
+        for (const it of list) {
+          if (it.encryptJobId) byId[it.encryptJobId] = it;
+          if (it.jobId) byId[it.jobId] = it;
+        }
+        if (list.length < 30) break;
+      }
+      for (const job of jobs) {
+        const it = byId[job.id];
+        if (!it) continue;
+        hit++;
+        applyApi(it, job);
+      }
+      return hit;
+    } catch (e) {
+      console.error('enrichFromApi:', e);
+      return 0;
+    }
   }
 
   async function scrape(count) {
@@ -45,6 +174,18 @@
       const container = document.querySelector('.job-list-container, .job-list-box, [class*="job-list"]');
       if (container) container.scrollTop = container.scrollHeight;
       await sleep(1200);
+    }
+    // API 补全：明文薪资 + 公司全名 + HR 名
+    await enrichFromApi(jobs);
+    // 收集统计：便于核对抓取质量
+    if (jobs.length) {
+      chrome.runtime.sendMessage({
+        type: 'LOG',
+        text: '收集完成：' + jobs.length + ' 个岗位（公司名 ' + jobs.filter(j => j.company).length
+          + '、薪资 ' + jobs.filter(j => /\d/.test(j.salary || '')).length
+          + '、活跃度 ' + jobs.filter(j => j.activity).length + '）',
+        level: 'info'
+      }).catch(() => {});
     }
     return jobs.slice(0, count);
   }
@@ -97,7 +238,17 @@
       const secs = document.querySelectorAll('.job-sec-text, [class*="job-sec"], [class*="job-desc"]');
       jd = Array.from(secs).map(s => (s.innerText || '').trim()).filter(Boolean).join('\n');
     }
-    return { success: true, jd: jd.slice(0, 1800) };
+    // 详情面板通常也有公司名，作为卡片抓取失败的兜底
+    let company = pickText(document, [
+      '.job-detail-box .company-info .name, .job-detail-box .company-info a',
+      '.job-detail-box [class*="company-name"]',
+      '.job-detail-box .company-info',
+      '[class*="job-detail"] [class*="company"]'
+    ]);
+    if (company && (company.match(/·/g) || []).length >= 2) company = '';
+    const hrName = pickText(document, ['.job-detail-box .boss-name', '.job-detail-box [class*="boss-name"]']);
+    const coLinkEl = document.querySelector('.job-detail-box a[href*="/gongsi/"], .job-detail-box a[href*="/company_detail/"]');
+    return { success: true, jd: jd.slice(0, 1800), company: company, companyLink: coLinkEl ? coLinkEl.href : '', hrName: hrName };
   }
 
   // 卡片已打开 → 点立即沟通 → 弹窗点"继续沟通"（跳转聊天页）

--- a/JobCopilot · AI/src/hook-api.js
+++ b/JobCopilot · AI/src/hook-api.js
@@ -1,0 +1,69 @@
+// MAIN world 脚本（document_start 注入，在页面自身脚本之前运行）：
+// 钩住页面自己的 fetch / XHR，截获 BOSS 搜索接口返回的明文岗位数据
+// （薪资在 DOM 里被字体反爬加密成乱码，但接口返回的 salaryDesc 是明文），
+// 通过 postMessage 交给 content script 使用。
+(function () {
+  if (window.__zpApiHooked) return;
+  window.__zpApiHooked = true;
+
+  var cache = [];
+
+  function capture(url, text) {
+    try {
+      if (!url || !text) return;
+      var hit = false;
+      try { hit = /zpgeek|joblist|wapi/i.test(url) || /salaryDesc/.test(text); } catch (e) {}
+      if (!hit) return;
+      var data = JSON.parse(text);
+      var list = data && data.zpData && Array.isArray(data.zpData.jobList) ? data.zpData.jobList : [];
+      if (!list.length) return;
+      cache.push({ url: url, list: list });
+      if (cache.length > 8) cache.shift();
+      window.postMessage({ source: 'zp-hook', payload: { url: url, list: list } }, '*');
+    } catch (e) {}
+  }
+
+  // 包一层 fetch
+  var origFetch = window.fetch;
+  if (typeof origFetch === 'function') {
+    window.fetch = function (input, init) {
+      var url = typeof input === 'string' ? input : (input && input.url) || '';
+      return origFetch.apply(this, arguments).then(function (resp) {
+        try {
+          if (resp && resp.ok && resp.clone) {
+            var ct = (resp.headers && resp.headers.get('content-type')) || '';
+            if (/json/i.test(ct) || /zpgeek|joblist|wapi/i.test(url)) {
+              resp.clone().text().then(function (t) { capture(url, t); }).catch(function () {});
+            }
+          }
+        } catch (e) {}
+        return resp;
+      });
+    };
+  }
+
+  // 包一层 XMLHttpRequest
+  var origOpen = XMLHttpRequest.prototype.open;
+  var origSend = XMLHttpRequest.prototype.send;
+  XMLHttpRequest.prototype.open = function (method, url) {
+    this.__zpUrl = url;
+    return origOpen.apply(this, arguments);
+  };
+  XMLHttpRequest.prototype.send = function () {
+    var xhr = this;
+    try {
+      xhr.addEventListener('load', function () {
+        var txt = xhr.responseText || (typeof xhr.response === 'string' ? xhr.response : (xhr.response ? JSON.stringify(xhr.response) : ''));
+        capture(xhr.__zpUrl || '', txt);
+      });
+    } catch (e) {}
+    return origSend.apply(this, arguments);
+  };
+
+  // content script 请求已缓存的数据
+  document.addEventListener('zp-hook-request', function () {
+    for (var i = 0; i < cache.length; i++) {
+      try { window.postMessage({ source: 'zp-hook', payload: cache[i] }, '*'); } catch (e) {}
+    }
+  });
+})();

--- a/JobCopilot · AI/src/selectors.js
+++ b/JobCopilot · AI/src/selectors.js
@@ -1,11 +1,14 @@
 // BOSS 直聘选择器（借鉴即投实测验证版）
 const SELECTORS = {
   jobs: {
-    jobCard: 'li.job-card-box',
+    // BOSS 不同版本/页面的卡片类名有差异，都试一遍
+    jobCard: 'li.job-card-box, .job-card-wrapper, li[class*="job-card"]',
     jobName: '.job-name',
-    jobSalary: '.job-salary',
-    tagList: '.tag-list li',
-    company: '.company-name, .boss-info .company-name, [class*="company-name"]',
+    jobSalary: '.job-salary, .salary',
+    jobArea: '.company-location, [class*="company-location"], .job-area, [class*="job-area"]',
+    tagList: '.tag-list li, .job-card-footer .tag-list li, [class*="job-tag"] li',
+    // 当前版卡片：公司名藏在 .boss-name（链接 /gongsi/ 公司页）；旧版在 .company-name
+    company: '.boss-info .boss-name, .boss-name, .company-info .company-name, .company-name, [class*="company-name"]',
     immediateChatBtn: 'a.op-btn-chat'
   },
   chat: {

--- a/JobCopilot · AI/src/sidepanel.css
+++ b/JobCopilot · AI/src/sidepanel.css
@@ -41,6 +41,10 @@ input[type=file] { width: 100%; font-size: 12px; }
 .job-main { flex: 1; }
 .job-title { font-weight: 600; }
 .job-sub { color: #888; font-size: 11.5px; margin-top: 2px; }
+.job-sub a.job-company { color: #008fd0; text-decoration: none; font-weight: 700; }
+.job-company { color: #1f2328; font-weight: 700; }
+.job-tags { margin-top: 3px; line-height: 1.5; }
+.job-tags span { display: inline-block; font-size: 10.5px; color: #666; background: #f1f3f5; border: 1px solid #e5e8ec; border-radius: 3px; padding: 0 5px; margin: 0 3px 2px 0; }
 .job-reason { font-size: 11.5px; margin-top: 2px; }
 .job-reason.m { color: #2b8a3e; } .job-reason.s { color: #c92a2a; }
 

--- a/JobCopilot · AI/src/sidepanel.html
+++ b/JobCopilot · AI/src/sidepanel.html
@@ -28,6 +28,19 @@
       <label>城市</label>
       <input type="text" id="city" placeholder="如：沈阳 / 北京">
 
+      <label>排除公司关键词（逗号分隔，命中即跳过）</label>
+      <input type="text" id="outKeywords" placeholder="如：外包, 人力, 派遣, 中软, 软通, 驻场">
+
+      <label>HR 活跃度要求</label>
+      <select id="activeFilter">
+        <option value="">不限</option>
+        <option value="5">刚刚活跃</option>
+        <option value="4">今日活跃（含刚刚）</option>
+        <option value="3">3日内活跃</option>
+        <option value="2">本周活跃</option>
+        <option value="1">本月活跃</option>
+      </select>
+
       <label>收集岗位数量</label>
       <input type="number" id="count" value="20" min="1" max="200">
 

--- a/JobCopilot · AI/src/sidepanel.js
+++ b/JobCopilot · AI/src/sidepanel.js
@@ -1,6 +1,6 @@
 // ===== 侧边栏交互 =====
 const $ = (id) => document.getElementById(id);
-const CFG_FIELDS = ['dsKey', 'resumeText', 'keyword', 'city', 'count'];
+const CFG_FIELDS = ['dsKey', 'resumeText', 'keyword', 'city', 'outKeywords', 'activeFilter', 'count'];
 
 // 折叠
 document.querySelectorAll('.card-h[data-toggle]').forEach(h => {
@@ -82,20 +82,31 @@ function renderReview(screened) {
   const skipped = screened.filter(j => !j.match);
   $('reviewCount').textContent = '匹配 ' + matched.length + ' / ' + screened.length;
   let html = '';
-  matched.forEach(j => {
-    html += '<div class="job-item"><input type="checkbox" checked data-id="' + esc(j.id) + '">'
-      + '<div class="job-main"><div class="job-title">' + esc(j.name) + '</div>'
-      + '<div class="job-sub">' + esc(j.company) + ' · ' + esc(j.salary) + '</div>'
-      + '<div class="job-reason m">✓ ' + esc(j.reason) + '</div></div></div>';
-  });
-  skipped.forEach(j => {
-    html += '<div class="job-item skip"><input type="checkbox" disabled data-id="' + esc(j.id) + '">'
-      + '<div class="job-main"><div class="job-title">' + esc(j.name) + '</div>'
-      + '<div class="job-sub">' + esc(j.company) + ' · ' + esc(j.salary) + '</div>'
-      + '<div class="job-reason s">✗ ' + esc(j.reason) + '</div></div></div>';
-  });
+  matched.forEach(j => { html += jobItemHtml(j, true); });
+  skipped.forEach(j => { html += jobItemHtml(j, false); });
   $('reviewList').innerHTML = html || '<div class="job-sub">无岗位</div>';
   $('reviewCard').style.display = 'block';
+}
+
+function jobItemHtml(j, matched) {
+  const sub = [];
+  if (j.company) {
+    const co = j.companyLink
+      ? '<a class="job-company" href="' + esc(j.companyLink) + '" target="_blank" rel="noopener">' + esc(j.company) + '</a>'
+      : '<span class="job-company">' + esc(j.company) + '</span>';
+    sub.push(co);
+  }
+  if (j.salary) sub.push(esc(j.salary));
+  if (j.area) sub.push(esc(j.area));
+  const tagHtml = (j.tags && j.tags.length)
+    ? '<div class="job-tags">' + j.tags.map(t => '<span>' + esc(t) + '</span>').join('') + '</div>'
+    : '';
+  return '<div class="job-item' + (matched ? '' : ' skip') + '"><input type="checkbox" ' + (matched ? 'checked' : 'disabled') + ' data-id="' + esc(j.id) + '">'
+    + '<div class="job-main"><div class="job-title">' + esc(j.name) + '</div>'
+    + '<div class="job-sub">' + sub.join(' · ') + '</div>'
+    + tagHtml
+    + '<div class="job-reason ' + (matched ? 'm' : 's') + '">' + (matched ? '✓' : '✗') + ' ' + esc(j.reason) + '</div>'
+    + '</div></div>';
 }
 function esc(s) { return (s || '').replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])); }
 


### PR DESCRIPTION
### 功能增强说明

1. **审核列表信息完整化**：显示公司名称（可点击公司主页）、工作地点、技能标签、明文薪资。
   新增 `hook-api.js`（MAIN world，document_start 注入），截获页面自身搜索接口数据，绕过 BOSS 薪资字体反爬，拿到明文 `salaryDesc`、公司全名、HR 名。

2. **外包公司过滤（双保险）**：本地黑名单关键词（配置项"排除公司关键词"，命中即跳过、不耗 API）+ AI 筛选规则（外包/劳务派遣/人力外包/知名外包企业如中软国际、软通动力等）。

3. **HR 活跃度筛选**：配置项"HR 活跃度要求"（不限/刚刚/今日/3日内/本周/本月），活跃度从卡片文本和接口数据抓取，不达标的岗位自动进"跳过"区。

4. **打招呼语个性化**：按 HR 名字自动生成称呼（"李女士"→"李姐"、"王先生"→"王哥"）；无后缀时按姓名用字性别偏好推断；信号不明确时使用"您好！"问候。开头统一为"您好！我熟悉XXX、XXX，做过……"。

### 测试方法
1. `edge://extensions` 加载解压缩的扩展
2. 配置 DeepSeek API Key、简历文字
3. 设置排除公司关键词、HR 活跃度要求
4. 开始收集 + AI 筛选：审核列表应显示公司名/薪资/活跃度，外包及活跃度不足的岗位进入"✗ 跳过"区
5. 投递时日志显示"称呼：X"，实际招呼语以称呼或"您好！"开头

### 兼容性说明
- 需要 Chrome / Edge 111+（使用了 content_scripts 的 `world: "MAIN"`）
- 薪资/公司名/HR 名通过截获页面自身的搜索接口获取，未新增任何额外网络请求